### PR TITLE
fix: store state (and event-listener) on element

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -34,14 +34,40 @@ export function setDefaults(options) {
   defaults = _extends({}, defaults, options);
 }
 
+function setup(el, clampValue) {
+  tearDown(el);
+
+  const resizeListener = () => {
+    clampElement(el, clampValue);
+  };
+
+  el.__VueClampy = {
+    clampValue,
+    resizeListener
+  };
+
+  // Re-clamp on element resize
+  // resizeDetector.listenTo(el, () => {
+  //   clampElement(el, clampValue);
+  // });
+
+  // Also re-clamp on window resize
+  window.addEventListener('resize', resizeListener);
+
+  clampElement(el, clampValue);
+}
+
+function tearDown(el) {
+  if (!el || !el.__VueClampy) return;
+  // Remove all listeners
+  // resizeDetector.removeAllListeners(el);
+  window.removeEventListener('resize', el.__VueClampy.resizeListener);
+}
+
 function setInitialContent(el) {
   if (el.clampInitialContent === undefined) {
     el.clampInitialContent = el.innerHTML.trim();
   }
-}
-
-function clampOnResize(el, clampValue) {
-  clampElement(el, clampValue);
 }
 
 function clampElement(el, clamp) {
@@ -77,27 +103,16 @@ function clampElement(el, clamp) {
 export default {
   inserted(el, binding, vnode) {
     clampValue = binding.value;
-    // Re-clamp on element resize
-    // resizeDetector.listenTo(el, () => {
-    //   clampElement(el, clampValue);
-    // });
-
-    // Also re-clamp on window resize
-    window.addEventListener('resize', clampOnResize);
-
-    clampElement(el, clampValue);
+    setup(el, clampValue);
   },
 
   update(el, binding, vnode) {
     clampValue = binding.value;
-    clampElement(el, clampValue);
+    setup(el, clampValue);
   },
 
   unbind(el, binding, vnode) {
-    clampValue = binding.value;
-
-    // Remove all listeners
-    // resizeDetector.removeAllListeners(el);
-    window.removeEventListener('resize', clampOnResize);
+    tearDown(el);
+    delete el.__VueClampy;
   }
 };

--- a/vue-clampy.js
+++ b/vue-clampy.js
@@ -321,14 +321,40 @@ function setDefaults(options) {
   defaults = _extends({}, defaults, options);
 }
 
+function setup(el, clampValue) {
+  tearDown(el);
+
+  var resizeListener = function resizeListener() {
+    clampElement(el, clampValue);
+  };
+
+  el.__VueClampy = {
+    clampValue: clampValue,
+    resizeListener: resizeListener
+  };
+
+  // Re-clamp on element resize
+  // resizeDetector.listenTo(el, () => {
+  //   clampElement(el, clampValue);
+  // });
+
+  // Also re-clamp on window resize
+  window.addEventListener('resize', resizeListener);
+
+  clampElement(el, clampValue);
+}
+
+function tearDown(el) {
+  if (!el || !el.__VueClampy) return;
+  // Remove all listeners
+  // resizeDetector.removeAllListeners(el);
+  window.removeEventListener('resize', el.__VueClampy.resizeListener);
+}
+
 function setInitialContent(el) {
   if (el.clampInitialContent === undefined) {
     el.clampInitialContent = el.innerHTML.trim();
   }
-}
-
-function clampOnResize(el, clampValue) {
-  clampElement(el, clampValue);
 }
 
 function clampElement(el, clamp) {
@@ -364,26 +390,15 @@ function clampElement(el, clamp) {
 var VueClampy$1 = {
   inserted: function inserted(el, binding, vnode) {
     clampValue = binding.value;
-    // Re-clamp on element resize
-    // resizeDetector.listenTo(el, () => {
-    //   clampElement(el, clampValue);
-    // });
-
-    // Also re-clamp on window resize
-    window.addEventListener('resize', clampOnResize);
-
-    clampElement(el, clampValue);
+    setup(el, clampValue);
   },
   update: function update(el, binding, vnode) {
     clampValue = binding.value;
-    clampElement(el, clampValue);
+    setup(el, clampValue);
   },
   unbind: function unbind(el, binding, vnode) {
-    clampValue = binding.value;
-
-    // Remove all listeners
-    // resizeDetector.removeAllListeners(el);
-    window.removeEventListener('resize', clampOnResize);
+    tearDown(el);
+    delete el.__VueClampy;
   }
 };
 


### PR DESCRIPTION
Hi again.

I pushed this without enough testing sorry.
resizeListener() doesn't have the right element and clampValue at hand.

I thought we could get away without it but it's mandatory to store some state (the event listener in this case) right on element, like most plugins do.

Now it's ok on my app at least ;)

Feel free to edit or ask for any modifications.